### PR TITLE
Handle multiple active labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ Common issues:
 3. **Empty scheduled stops**
    - Verify Phase and Day of Week combination exists
    - Check route number is correct
-   - Ensure stops are marked as Active='Y'
+   - Ensure stops are marked as active ('Y' or 'Active')

--- a/route_processor.py
+++ b/route_processor.py
@@ -117,11 +117,12 @@ class RouteDataLoader:
 
         # Load all stops and filter
         all_stops_df = self.load_all_stops()
+        active_col = all_stops_df['Active'].astype(str).str.lower()
         scheduled_stops = all_stops_df[
             (all_stops_df['Route Num'] == route_num) &
             (all_stops_df['Phase'] == phase) &
             (all_stops_df['Day Of Week'] == day_of_week) &
-            (all_stops_df['Active'] == 'Y')
+            (active_col.isin(['y', 'active']))
         ].copy()
 
         # Sort by sequence


### PR DESCRIPTION
## Summary
- support 'Y' or 'Active' entries for scheduled stops
- clarify README troubleshooting for active stops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881511d95c88328846aae5c9b2a01ff