### PR TITLE
Fix phase comparison in scheduled stop lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,5 @@ Common issues:
    - Verify Phase and Day of Week combination exists
    - Check route number is correct
    - Ensure stops are marked as active ('Y' or 'Active')
+   - Confirm phase names ("One", "Two", etc.) match the numeric notation
+     ("1 Only", "2 Only", ...) used in `Stops.csv`


### PR DESCRIPTION
## Summary
- normalize phase names between date conversions and stops
- note the numeric phase format in troubleshooting docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688152c9e6f08328a4b5f784c3ca6604