### PR TITLE
Add jeco_route_processor package

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install pandas geopy
 
 ```python
 from pathlib import Path
-from route_processor import RouteProcessor, RouteConfig
+from jeco_route_processor import RouteProcessor, RouteConfig
 
 # Configure processing
 config = RouteConfig(
@@ -70,7 +70,7 @@ config = RouteConfig(
 
 Process multiple routes and dates:
 ```python
-from utils import run_batch_processing
+from jeco_route_processor import run_batch_processing
 
 routes = [600, 601, 602, 603, 604]
 dates = ["January 13, 2025", "January 14, 2025", "January 15, 2025"]
@@ -128,7 +128,7 @@ The generated metadata JSON includes:
 Use the utilities module to calculate route efficiency:
 
 ```python
-from utils import RouteStatistics, analyze_metadata_file
+from jeco_route_processor import RouteStatistics, analyze_metadata_file
 
 # Analyze a single route
 analyze_metadata_file(Path("./data/metadata/route_metadata_RT604_January_15_2025.json"))
@@ -144,7 +144,7 @@ stats = RouteStatistics.calculate_route_efficiency(metadata)
 The system includes validation checks:
 
 ```python
-from utils import DataValidator
+from jeco_route_processor import DataValidator
 
 # Validate stops data
 warnings = DataValidator.validate_stops_data(stops_df)
@@ -156,7 +156,7 @@ warnings = DataValidator.validate_trips_data(trips_data)
 ## Adding New Warehouses
 
 ```python
-from utils import WarehouseLocations
+from jeco_route_processor import WarehouseLocations
 
 WarehouseLocations.add_warehouse(
     location_name="Dallas",

--- a/example_usage.py
+++ b/example_usage.py
@@ -4,8 +4,13 @@ Shows different ways to use the route processor
 """
 
 from pathlib import Path
-from route_processor import RouteProcessor, RouteConfig
-from utils import DateFormatter, analyze_metadata_file, run_batch_processing
+from jeco_route_processor import (
+    RouteProcessor,
+    RouteConfig,
+    DateFormatter,
+    analyze_metadata_file,
+    run_batch_processing,
+)
 import json
 
 

--- a/jeco_route_processor/__init__.py
+++ b/jeco_route_processor/__init__.py
@@ -1,0 +1,36 @@
+"""Top-level package for JECO Route Processor."""
+
+from .route_processor import (
+    RouteProcessor,
+    RouteConfig,
+    Location,
+    Alert,
+    RouteDataLoader,
+    RouteAnalyzer,
+    MetadataGenerator,
+)
+
+from .utils import (
+    DateFormatter,
+    WarehouseLocations,
+    DataValidator,
+    RouteStatistics,
+    run_batch_processing,
+    analyze_metadata_file,
+)
+
+__all__ = [
+    "RouteProcessor",
+    "RouteConfig",
+    "Location",
+    "Alert",
+    "RouteDataLoader",
+    "RouteAnalyzer",
+    "MetadataGenerator",
+    "DateFormatter",
+    "WarehouseLocations",
+    "DataValidator",
+    "RouteStatistics",
+    "run_batch_processing",
+    "analyze_metadata_file",
+]

--- a/jeco_route_processor/route_processor.py
+++ b/jeco_route_processor/route_processor.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, asdict
 from geopy.distance import distance
 import logging
-from utils import DateFormatter
+from .utils import DateFormatter
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/jeco_route_processor/utils.py
+++ b/jeco_route_processor/utils.py
@@ -218,7 +218,7 @@ def run_batch_processing(data_dir: Path, routes: List[int], dates: List[str]):
         routes: List of route numbers to process
         dates: List of date strings to process
     """
-    from route_processor import RouteProcessor, RouteConfig
+    from .route_processor import RouteProcessor, RouteConfig
 
     results = []
 

--- a/setup_and_test.py
+++ b/setup_and_test.py
@@ -79,8 +79,7 @@ def test_basic_processing():
     print("\nTesting basic processing...")
 
     try:
-        from route_processor import RouteProcessor, RouteConfig
-        from utils import analyze_metadata_file
+        from jeco_route_processor import RouteProcessor, RouteConfig, analyze_metadata_file
 
         # Test configuration
         config = RouteConfig(


### PR DESCRIPTION
## Summary
- move `route_processor.py` and `utils.py` into a new `jeco_route_processor` package
- expose key classes/functions in `jeco_route_processor/__init__.py`
- adjust imports in scripts and docs

## Testing
- `python -m compileall -q jeco_route_processor`
- `pip install -e .`
- `python setup_and_test.py` *(fails: Dates/ directory MISSING)*

------
https://chatgpt.com/codex/tasks/task_e_68815a2ded708328bf18171878e7e709