### PR TITLE
Generate new route outputs

### DIFF
--- a/jeco_route_processor/route_processor.py
+++ b/jeco_route_processor/route_processor.py
@@ -347,14 +347,17 @@ class RouteAnalyzer:
         """Find orders within radius of a stop"""
         nearby_orders: List[Dict] = []
 
+        # Drop any orders without coordinates to avoid KDTree errors
+        valid_orders = orders_df.dropna(subset=['Latitude', 'Longitude']).reset_index(drop=True)
+
         order_locs = [
             Location(row['Latitude'], row['Longitude'])
-            for _, row in orders_df.iterrows()
+            for _, row in valid_orders.iterrows()
         ]
 
         idxs, dists = nearest_points(order_locs, stop_loc, self.config.alert_radius_meters)
         for i, dist in zip(idxs, dists):
-            order = orders_df.iloc[i]
+            order = valid_orders.iloc[i]
             nearby_orders.append({
                 'customer_name': order['Customer Name'],
                 'start_time': order['Start Time'],

--- a/tests/fixtures/metadata/route_metadata_RT600_March_14,_2025.json
+++ b/tests/fixtures/metadata/route_metadata_RT600_March_14,_2025.json
@@ -1,0 +1,1643 @@
+{
+  "version": "1.0",
+  "generated_at": "2025-07-24T20:53:08.335832",
+  "route_info": {
+    "route_number": 600,
+    "date": "March 14, 2025",
+    "vehicle_name": "CHA-AUS 303273 600",
+    "warehouse": {
+      "name": "Austin Warehouse",
+      "location": {
+        "latitude": 30.20037956,
+        "longitude": -97.71581548
+      }
+    }
+  },
+  "summary": {
+    "total_scheduled_stops": 13,
+    "total_gps_trips": 15,
+    "total_orders": 23,
+    "total_alerts": 15,
+    "stops_visited": 9,
+    "stops_with_orders": 8,
+    "unscheduled_stops": 6
+  },
+  "scheduled_stops": [
+    {
+      "stop_id": 2859027,
+      "sequence": 1,
+      "customer_name": "RANDALLS #2987",
+      "location": {
+        "latitude": 30.388927,
+        "longitude": -97.884142
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741966471150,
+          "address": "RANDALLS #2987",
+          "distance_meters": 46.1516118760584
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741961053030,
+          "address": "RANDALLS #2987",
+          "distance_meters": 33.280859548503756
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "RANDALLS #2987",
+          "start_time": "3/14/2025 9:54 AM",
+          "end_time": "3/14/2025 10:13 AM",
+          "duration_minutes": 18.85,
+          "user": "Aaron Day",
+          "distance_meters": 13.770247742206665
+        },
+        {
+          "customer_name": "RANDALLS #2987",
+          "start_time": "3/14/2025 9:39 AM",
+          "end_time": "3/14/2025 9:54 AM",
+          "duration_minutes": 15.78,
+          "user": "Aaron Day",
+          "distance_meters": 13.770247742206665
+        },
+        {
+          "customer_name": "MARSHALL FORD GROCERY",
+          "start_time": "3/14/2025 10:40 AM",
+          "end_time": "3/14/2025 10:41 AM",
+          "duration_minutes": 0.47,
+          "user": "Aaron Day",
+          "distance_meters": 30.874782851986126
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2858982,
+      "sequence": 2,
+      "customer_name": "TARGET #1953",
+      "location": {
+        "latitude": 30.402406,
+        "longitude": -97.850503
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    },
+    {
+      "stop_id": 2858959,
+      "sequence": 3,
+      "customer_name": "RUDYS COUNTRY STORE #4",
+      "location": {
+        "latitude": 30.410561,
+        "longitude": -97.849497
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741959359029,
+          "address": "RUDYS COUNTRY STORE #4",
+          "distance_meters": 30.11036696841073
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741958146021,
+          "address": "RUDYS COUNTRY STORE #4",
+          "distance_meters": 40.40282403572823
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "HOME DEPOT #8418",
+          "start_time": "3/14/2025 8:43 AM",
+          "end_time": "3/14/2025 8:50 AM",
+          "duration_minutes": 7.13,
+          "user": "Aaron Day",
+          "distance_meters": 36.30436465973808
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2858960,
+      "sequence": 4,
+      "customer_name": "HOME DEPOT #8418",
+      "location": {
+        "latitude": 30.41475,
+        "longitude": -97.850664
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741960390025,
+          "address": "HOME DEPOT #8418",
+          "distance_meters": 73.37117965339513
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741959709016,
+          "address": "HOME DEPOT #8418",
+          "distance_meters": 71.17740771751909
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "RANDALLS #2987",
+          "start_time": "3/14/2025 9:18 AM",
+          "end_time": "3/14/2025 9:33 AM",
+          "duration_minutes": 15.03,
+          "user": "Aaron Day",
+          "distance_meters": 57.40674381260054
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2858929,
+      "sequence": 5,
+      "customer_name": "7 ELEVEN #36564",
+      "location": {
+        "latitude": 30.403585,
+        "longitude": -97.854771
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741957860068,
+          "address": "7 ELEVEN #36564",
+          "distance_meters": 7.668008169906506
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741956573024,
+          "address": "7 ELEVEN #36564",
+          "distance_meters": 12.313748988602342
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "RUDYS COUNTRY STORE #4",
+          "start_time": "3/14/2025 8:19 AM",
+          "end_time": "3/14/2025 8:35 AM",
+          "duration_minutes": 15.12,
+          "user": "Aaron Day",
+          "distance_meters": 3.5215063929890547
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2858928,
+      "sequence": 6,
+      "customer_name": "REFUEL #1316",
+      "location": {
+        "latitude": 30.369461,
+        "longitude": -97.892539
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    },
+    {
+      "stop_id": 2868478,
+      "sequence": 7,
+      "customer_name": "LAKE TRAVIS FIRE RESCUE",
+      "location": {
+        "latitude": 30.3634213,
+        "longitude": -97.9509861
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741973855152,
+          "address": "LAKE TRAVIS FIRE RESCUE",
+          "distance_meters": 13.717981425334251
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741973476011,
+          "address": "LAKE TRAVIS FIRE RESCUE",
+          "distance_meters": 10.974835139244835
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "LAKE TRAVIS FIRE RESCUE",
+          "start_time": "3/14/2025 12:30 PM",
+          "end_time": "3/14/2025 12:32 PM",
+          "duration_minutes": 1.8,
+          "user": "Aaron Day",
+          "distance_meters": 5.612480669217438
+        },
+        {
+          "customer_name": "FOOD ZONE #2",
+          "start_time": "3/14/2025 12:37 PM",
+          "end_time": "3/14/2025 12:37 PM",
+          "duration_minutes": 0.08,
+          "user": "Aaron Day",
+          "distance_meters": 6.627816770997208
+        },
+        {
+          "customer_name": "FOOD ZONE #2",
+          "start_time": "3/14/2025 12:45 PM",
+          "end_time": "3/14/2025 12:48 PM",
+          "duration_minutes": 2.72,
+          "user": "Aaron Day",
+          "distance_meters": 6.627816770997208
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2862983,
+      "sequence": 8,
+      "customer_name": "YETI LIQUOR",
+      "location": {
+        "latitude": 30.369528,
+        "longitude": -97.892738
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    },
+    {
+      "stop_id": 2939248,
+      "sequence": 9,
+      "customer_name": "CORK & BREW EXPRESS (RANCH RD)",
+      "location": {
+        "latitude": 30.1986701,
+        "longitude": -97.8273606
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    },
+    {
+      "stop_id": 2858958,
+      "sequence": 10,
+      "customer_name": "HUDSON BEND GROCERY",
+      "location": {
+        "latitude": 30.412476,
+        "longitude": -97.926553
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741971028040,
+          "address": "HUDSON BEND GROCERY",
+          "distance_meters": 18.291778760294306
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741970516014,
+          "address": "HUDSON BEND GROCERY",
+          "distance_meters": 21.875810516116942
+        }
+      ],
+      "orders": [],
+      "has_gps_visit": true,
+      "has_order": false
+    },
+    {
+      "stop_id": 2862111,
+      "sequence": 11,
+      "customer_name": "7 ELEVEN #36559",
+      "location": {
+        "latitude": 30.39815,
+        "longitude": -97.928428
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741970082014,
+          "address": "7 ELEVEN #36559",
+          "distance_meters": 53.079503493964076
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741968714029,
+          "address": "7 ELEVEN #36559",
+          "distance_meters": 51.76754287457485
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "7 ELEVEN #36559",
+          "start_time": "3/14/2025 11:33 AM",
+          "end_time": "3/14/2025 11:33 AM",
+          "duration_minutes": 0.1,
+          "user": "Aaron Day",
+          "distance_meters": 16.23417551068342
+        },
+        {
+          "customer_name": "HUDSON BEND GROCERY",
+          "start_time": "3/14/2025 11:43 AM",
+          "end_time": "3/14/2025 11:49 AM",
+          "duration_minutes": 5.92,
+          "user": "Aaron Day",
+          "distance_meters": 52.36891639713779
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2858930,
+      "sequence": 12,
+      "customer_name": "MERITO FOOD MART",
+      "location": {
+        "latitude": 30.367062,
+        "longitude": -97.950126
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741973157028,
+          "address": "MERITO FOOD MART",
+          "distance_meters": 16.01265983291034
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741971598164,
+          "address": "MERITO FOOD MART",
+          "distance_meters": 19.869008617960155
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "MERITO FOOD MART",
+          "start_time": "3/14/2025 12:06 PM",
+          "end_time": "3/14/2025 12:21 PM",
+          "duration_minutes": 15.45,
+          "user": "Aaron Day",
+          "distance_meters": 34.044235760187334
+        },
+        {
+          "customer_name": "MERITO FOOD MART",
+          "start_time": "3/14/2025 12:03 PM",
+          "end_time": "3/14/2025 12:03 PM",
+          "duration_minutes": 0.07,
+          "user": "Aaron Day",
+          "distance_meters": 34.044235760187334
+        },
+        {
+          "customer_name": "MERITO FOOD MART",
+          "start_time": "3/14/2025 12:21 PM",
+          "end_time": "3/14/2025 12:25 PM",
+          "duration_minutes": 3.43,
+          "user": "Aaron Day",
+          "distance_meters": 34.044235760187334
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2862637,
+      "sequence": 13,
+      "customer_name": "FOOD ZONE #2",
+      "location": {
+        "latitude": 30.349192,
+        "longitude": -97.9631
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1741974987022,
+          "address": "FOOD ZONE #2",
+          "distance_meters": 48.5827977185908
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1741974163029,
+          "address": "FOOD ZONE #2",
+          "distance_meters": 26.83731511396651
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "TARGET #1812",
+          "start_time": "3/14/2025 1:18 PM",
+          "end_time": "3/14/2025 1:35 PM",
+          "duration_minutes": 17.07,
+          "user": "Aaron Day",
+          "distance_meters": 12.586556405527599
+        },
+        {
+          "customer_name": "TARGET #1812",
+          "start_time": "3/14/2025 12:54 PM",
+          "end_time": "3/14/2025 12:54 PM",
+          "duration_minutes": 0.53,
+          "user": "Aaron Day",
+          "distance_meters": 12.586556405527599
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    }
+  ],
+  "gps_trips": [
+    {
+      "startMs": 1741952167018,
+      "endMs": 1741954783111,
+      "startLocation": "Flint Rock Loop, Austin, TX",
+      "endLocation": "Four Points Drive, Austin, TX",
+      "startAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "endAddress": {
+        "id": 23570552,
+        "name": "TARGET #1953",
+        "address": "11220 RANCH ROAD 2222, AUSTIN, TX 78730"
+      },
+      "startCoordinates": {
+        "latitude": 30.20054109,
+        "longitude": -97.71603025
+      },
+      "endCoordinates": {
+        "latitude": 30.40347901,
+        "longitude": -97.8505148
+      },
+      "distanceMeters": 38066,
+      "fuelConsumedMl": 7602,
+      "tollMeters": 0,
+      "driverId": 50785921,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741956355078,
+      "endMs": 1741956573024,
+      "startLocation": "Four Points Drive, Austin, TX",
+      "endLocation": "RM 620, Austin, TX",
+      "startAddress": {
+        "id": 23570552,
+        "name": "TARGET #1953",
+        "address": "11220 RANCH ROAD 2222, AUSTIN, TX 78730"
+      },
+      "endAddress": {
+        "id": 23570643,
+        "name": "7 ELEVEN #36564",
+        "address": "7002 RANCH ROAD 620 N, AUSTIN, TX 78732"
+      },
+      "startCoordinates": {
+        "latitude": 30.40345091,
+        "longitude": -97.8505041
+      },
+      "endCoordinates": {
+        "latitude": 30.40347928,
+        "longitude": -97.85473169
+      },
+      "distanceMeters": 1072,
+      "fuelConsumedMl": 202,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741957860068,
+      "endMs": 1741958146021,
+      "startLocation": "RM 620, Austin, TX",
+      "endLocation": "Austin, TX",
+      "startAddress": {
+        "id": 23570643,
+        "name": "7 ELEVEN #36564",
+        "address": "7002 RANCH ROAD 620 N, AUSTIN, TX 78732"
+      },
+      "endAddress": {
+        "id": 23570629,
+        "name": "RUDYS COUNTRY STORE #4",
+        "address": "7709 N FM 620, AUSTIN, TX 78726"
+      },
+      "startCoordinates": {
+        "latitude": 30.40352229,
+        "longitude": -97.85480467
+      },
+      "endCoordinates": {
+        "latitude": 30.41020529,
+        "longitude": -97.849588539
+      },
+      "distanceMeters": 1279,
+      "fuelConsumedMl": 216,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741959359029,
+      "endMs": 1741959709016,
+      "startLocation": "Austin, TX",
+      "endLocation": "Woodbay Parke Drive, Austin, TX",
+      "startAddress": {
+        "id": 23570629,
+        "name": "RUDYS COUNTRY STORE #4",
+        "address": "7709 N FM 620, AUSTIN, TX 78726"
+      },
+      "endAddress": {
+        "id": 23571297,
+        "name": "HOME DEPOT #8418",
+        "address": "7900 N FM 620, AUSTIN, TX 78726"
+      },
+      "startCoordinates": {
+        "latitude": 30.41030025,
+        "longitude": -97.84958472
+      },
+      "endCoordinates": {
+        "latitude": 30.41537849,
+        "longitude": -97.850815449
+      },
+      "distanceMeters": 1217,
+      "fuelConsumedMl": 312,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741960390025,
+      "endMs": 1741961053030,
+      "startLocation": "Woodbay Parke Drive, Austin, TX",
+      "endLocation": "RM 620, 5.9 mi ENE Lakeway, Travis County, TX",
+      "startAddress": {
+        "id": 23571297,
+        "name": "HOME DEPOT #8418",
+        "address": "7900 N FM 620, AUSTIN, TX 78726"
+      },
+      "endAddress": {
+        "id": 23570986,
+        "name": "RANDALLS #2987",
+        "address": "5145 RANCH ROAD 620 N STE A, AUSTIN, TX 78732"
+      },
+      "startCoordinates": {
+        "latitude": 30.415394289,
+        "longitude": -97.85083869
+      },
+      "endCoordinates": {
+        "latitude": 30.38863303,
+        "longitude": -97.88421223
+      },
+      "distanceMeters": 6015,
+      "fuelConsumedMl": 762,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741966471150,
+      "endMs": 1741966677062,
+      "startLocation": "RM 620, 5.9 mi ENE Lakeway, Travis County, TX",
+      "endLocation": "RM 620, 5.6 mi ENE Lakeway, Travis County, TX",
+      "startAddress": {
+        "id": 23570986,
+        "name": "RANDALLS #2987",
+        "address": "5145 RANCH ROAD 620 N STE A, AUSTIN, TX 78732"
+      },
+      "endAddress": {
+        "id": 23570194,
+        "name": "MARSHALL FORD GROCERY",
+        "address": "4610 N HWY 620, AUSTIN, TX 78732"
+      },
+      "startCoordinates": {
+        "latitude": 30.38857634,
+        "longitude": -97.88440083
+      },
+      "endCoordinates": {
+        "latitude": 30.38953125,
+        "longitude": -97.89087024
+      },
+      "distanceMeters": 946,
+      "fuelConsumedMl": 237,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741967179117,
+      "endMs": 1741968714029,
+      "startLocation": "RM 620, 5.6 mi ENE Lakeway, Travis County, TX",
+      "endLocation": "RM 620, Lakeway, TX",
+      "startAddress": {
+        "id": 23570194,
+        "name": "MARSHALL FORD GROCERY",
+        "address": "4610 N HWY 620, AUSTIN, TX 78732"
+      },
+      "endAddress": {
+        "id": 23570300,
+        "name": "7 ELEVEN #36559",
+        "address": "3636 RANCH ROAD 620 N, AUSTIN, TX 78734"
+      },
+      "startCoordinates": {
+        "latitude": 30.38951271,
+        "longitude": -97.89085772
+      },
+      "endCoordinates": {
+        "latitude": 30.39793958,
+        "longitude": -97.9279471
+      },
+      "distanceMeters": 12075,
+      "fuelConsumedMl": 2025,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741970082014,
+      "endMs": 1741970516014,
+      "startLocation": "RM 620, Lakeway, TX",
+      "endLocation": "Hudson Bend Road, Hudson Bend, TX",
+      "startAddress": {
+        "id": 23570300,
+        "name": "7 ELEVEN #36559",
+        "address": "3636 RANCH ROAD 620 N, AUSTIN, TX 78734"
+      },
+      "endAddress": {
+        "id": 23570141,
+        "name": "HUDSON BEND GROCERY",
+        "address": "5001 HUDSON BEND RD, AUSTIN, TX 78734"
+      },
+      "startCoordinates": {
+        "latitude": 30.3979261,
+        "longitude": -97.92793977
+      },
+      "endCoordinates": {
+        "latitude": 30.412516439,
+        "longitude": -97.92677584
+      },
+      "distanceMeters": 2011,
+      "fuelConsumedMl": 380,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741971028040,
+      "endMs": 1741971598164,
+      "startLocation": "Hudson Bend Road, Hudson Bend, TX",
+      "endLocation": "Nightingale Lane, Lakeway, TX",
+      "startAddress": {
+        "id": 23570141,
+        "name": "HUDSON BEND GROCERY",
+        "address": "5001 HUDSON BEND RD, AUSTIN, TX 78734"
+      },
+      "endAddress": {
+        "id": 23570389,
+        "name": "MERITO FOOD MART",
+        "address": "201 RANCH ROAD 620 N, AUSTIN, TX 78734"
+      },
+      "startCoordinates": {
+        "latitude": 30.41244755,
+        "longitude": -97.92674052
+      },
+      "endCoordinates": {
+        "latitude": 30.3670098,
+        "longitude": -97.94992827
+      },
+      "distanceMeters": 6057,
+      "fuelConsumedMl": 1195,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741973157028,
+      "endMs": 1741973476011,
+      "startLocation": "Nightingale Lane, Lakeway, TX",
+      "endLocation": "Whippoorwill Street South, Lakeway, TX",
+      "startAddress": {
+        "id": 23570389,
+        "name": "MERITO FOOD MART",
+        "address": "201 RANCH ROAD 620 N, AUSTIN, TX 78734"
+      },
+      "endAddress": {
+        "id": 263840549,
+        "name": "LAKE TRAVIS FIRE RESCUE",
+        "address": "15304 PHEASANT LANE, LAKEWAY, TX 78734"
+      },
+      "startCoordinates": {
+        "latitude": 30.36701017,
+        "longitude": -97.949970519
+      },
+      "endCoordinates": {
+        "latitude": 30.36344248,
+        "longitude": -97.95109762
+      },
+      "distanceMeters": 1066,
+      "fuelConsumedMl": 373,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741973855152,
+      "endMs": 1741974163029,
+      "startLocation": "Whippoorwill Street South, Lakeway, TX",
+      "endLocation": "Gebron Drive, Lakeway, TX",
+      "startAddress": {
+        "id": 263840549,
+        "name": "LAKE TRAVIS FIRE RESCUE",
+        "address": "15304 PHEASANT LANE, LAKEWAY, TX 78734"
+      },
+      "endAddress": {
+        "id": 32558680,
+        "name": "FOOD ZONE #2",
+        "address": "1405 S RANCH ROAD 620, LAKEWAY, TX 78734"
+      },
+      "startCoordinates": {
+        "latitude": 30.36345427,
+        "longitude": -97.95112364
+      },
+      "endCoordinates": {
+        "latitude": 30.34929449,
+        "longitude": -97.96335288
+      },
+      "distanceMeters": 2229,
+      "fuelConsumedMl": 362,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741974987022,
+      "endMs": 1741976595021,
+      "startLocation": "RM 620, Lakeway, TX",
+      "endLocation": "Ladera Boulevard, Bee Cave, TX",
+      "startAddress": {
+        "id": 32558680,
+        "name": "FOOD ZONE #2",
+        "address": "1405 S RANCH ROAD 620, LAKEWAY, TX 78734"
+      },
+      "endAddress": {
+        "id": 23570587,
+        "name": "TARGET #1812",
+        "address": "3702 RANCH ROAD 620 S, AUSTIN, TX 78738"
+      },
+      "startCoordinates": {
+        "latitude": 30.34938965,
+        "longitude": -97.96355099
+      },
+      "endCoordinates": {
+        "latitude": 30.31701331,
+        "longitude": -97.95384564
+      },
+      "distanceMeters": 6135,
+      "fuelConsumedMl": 1655,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741977814023,
+      "endMs": 1741978869004,
+      "startLocation": "Ladera Boulevard, Bee Cave, TX",
+      "endLocation": "Highway 71 West, Austin, TX",
+      "startAddress": {
+        "id": 23570587,
+        "name": "TARGET #1812",
+        "address": "3702 RANCH ROAD 620 S, AUSTIN, TX 78738"
+      },
+      "startCoordinates": {
+        "latitude": 30.316966229,
+        "longitude": -97.953874619
+      },
+      "endCoordinates": {
+        "latitude": 30.23543287,
+        "longitude": -97.87553197
+      },
+      "distanceMeters": 13006,
+      "fuelConsumedMl": 2349,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741980299047,
+      "endMs": 1741981647013,
+      "startLocation": "Highway 71 West, Austin, TX",
+      "endLocation": "Flint Rock Loop, Austin, TX",
+      "endAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "startCoordinates": {
+        "latitude": 30.23539533,
+        "longitude": -97.87551658
+      },
+      "endCoordinates": {
+        "latitude": 30.20028733,
+        "longitude": -97.71600984
+      },
+      "distanceMeters": 18285,
+      "fuelConsumedMl": 2836,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1741983156029,
+      "endMs": 1741983188030,
+      "startLocation": "Flint Rock Loop, Austin, TX",
+      "endLocation": "Flint Rock Loop, Austin, TX",
+      "startAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "endAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "startCoordinates": {
+        "latitude": 30.2003983,
+        "longitude": -97.71598337
+      },
+      "endCoordinates": {
+        "latitude": 30.200200099,
+        "longitude": -97.71594403
+      },
+      "distanceMeters": 38,
+      "fuelConsumedMl": 0,
+      "tollMeters": 0,
+      "driverId": 0,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    }
+  ],
+  "orders": [
+    {
+      "Time Clock Event ID": 52526414,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "TARGET #1812",
+      "Route": "600 Tue (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 1:35 PM",
+      "End Time": "3/14/2025 1:36 PM",
+      "Minutes": 0.63,
+      "Latitude": 30.31582514441495,
+      "Longitude": -97.95421679498808,
+      "Time Updated": "3/14/2025 1:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 1:38 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52526412,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "TARGET #1812",
+      "Route": "600 Tue (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 1:18 PM",
+      "End Time": "3/14/2025 1:35 PM",
+      "Minutes": 17.07,
+      "Latitude": 30.34929550696075,
+      "Longitude": -97.96315379798342,
+      "Time Updated": "3/14/2025 1:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 1:38 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52526410,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "TARGET #1812",
+      "Route": "600 Tue (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 12:54 PM",
+      "End Time": "3/14/2025 12:54 PM",
+      "Minutes": 0.53,
+      "Latitude": 30.34929550696075,
+      "Longitude": -97.96315379798342,
+      "Time Updated": "3/14/2025 1:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 1:38 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52524851,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "FOOD ZONE #2",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 12:45 PM",
+      "End Time": "3/14/2025 12:48 PM",
+      "Minutes": 2.72,
+      "Latitude": 30.36342159896893,
+      "Longitude": -97.95105504353828,
+      "Time Updated": "3/14/2025 1:05 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 12:53 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52524850,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "FOOD ZONE #2",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 12:37 PM",
+      "End Time": "3/14/2025 12:37 PM",
+      "Minutes": 0.08,
+      "Latitude": 30.36342159896893,
+      "Longitude": -97.95105504353828,
+      "Time Updated": "3/14/2025 1:05 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 12:53 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52524049,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "LAKE TRAVIS FIRE RESCUE",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 12:30 PM",
+      "End Time": "3/14/2025 12:32 PM",
+      "Minutes": 1.8,
+      "Latitude": 30.3634236039076,
+      "Longitude": -97.95104442210774,
+      "Time Updated": "3/14/2025 1:05 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 12:35 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52523681,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "MERITO FOOD MART",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 12:21 PM",
+      "End Time": "3/14/2025 12:25 PM",
+      "Minutes": 3.43,
+      "Latitude": 30.36680014815294,
+      "Longitude": -97.9503110250342,
+      "Time Updated": "3/14/2025 12:34 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 12:25 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52523680,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "MERITO FOOD MART",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 12:06 PM",
+      "End Time": "3/14/2025 12:21 PM",
+      "Minutes": 15.45,
+      "Latitude": 30.36680014815294,
+      "Longitude": -97.9503110250342,
+      "Time Updated": "3/14/2025 12:34 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 12:25 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52523679,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "MERITO FOOD MART",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 12:03 PM",
+      "End Time": "3/14/2025 12:03 PM",
+      "Minutes": 0.07,
+      "Latitude": 30.36680014815294,
+      "Longitude": -97.9503110250342,
+      "Time Updated": "3/14/2025 12:34 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 12:25 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52522142,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "HUDSON BEND GROCERY",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 11:43 AM",
+      "End Time": "3/14/2025 11:49 AM",
+      "Minutes": 5.92,
+      "Latitude": 30.39794113489841,
+      "Longitude": -97.92793921204093,
+      "Time Updated": "3/14/2025 12:04 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 11:49 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52521384,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "7 ELEVEN #36559",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 11:33 AM",
+      "End Time": "3/14/2025 11:33 AM",
+      "Minutes": 0.1,
+      "Latitude": 30.39819311492549,
+      "Longitude": -97.9282665556092,
+      "Time Updated": "3/14/2025 12:04 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 11:34 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52521382,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "7 ELEVEN #36559",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 11:13 AM",
+      "End Time": "3/14/2025 11:29 AM",
+      "Minutes": 16.73,
+      "Latitude": 30.36992057270492,
+      "Longitude": -97.89363124830729,
+      "Time Updated": "3/14/2025 12:04 PM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 11:34 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52520023,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "YETI LIQUOR",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 10:57 AM",
+      "End Time": "3/14/2025 10:58 AM",
+      "Minutes": 0.9,
+      "Latitude": 30.38951288686794,
+      "Longitude": -97.89086150747536,
+      "Time Updated": "3/14/2025 11:00 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 10:59 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52519376,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "MARSHALL FORD GROCERY",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 10:40 AM",
+      "End Time": "3/14/2025 10:41 AM",
+      "Minutes": 0.47,
+      "Latitude": 30.38865017901043,
+      "Longitude": -97.88417727344984,
+      "Time Updated": "3/14/2025 11:00 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 10:43 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52518990,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "RANDALLS #2987",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 9:54 AM",
+      "End Time": "3/14/2025 10:13 AM",
+      "Minutes": 18.85,
+      "Latitude": 30.38902028302086,
+      "Longitude": -97.88404739014824,
+      "Time Updated": "3/14/2025 11:00 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 10:33 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52518989,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "RANDALLS #2987",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 9:39 AM",
+      "End Time": "3/14/2025 9:54 AM",
+      "Minutes": 15.78,
+      "Latitude": 30.38902028302086,
+      "Longitude": -97.88404739014824,
+      "Time Updated": "3/14/2025 11:00 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 10:33 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52518988,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "RANDALLS #2987",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 9:18 AM",
+      "End Time": "3/14/2025 9:33 AM",
+      "Minutes": 15.03,
+      "Latitude": 30.41524856825705,
+      "Longitude": -97.85082545415064,
+      "Time Updated": "3/14/2025 11:00 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 10:33 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52515088,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "HOME DEPOT #8418",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 8:43 AM",
+      "End Time": "3/14/2025 8:50 AM",
+      "Minutes": 7.13,
+      "Latitude": 30.4102360991466,
+      "Longitude": -97.84954433672998,
+      "Time Updated": "3/14/2025 9:15 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 8:51 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52514495,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "RUDYS COUNTRY STORE #4",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 8:19 AM",
+      "End Time": "3/14/2025 8:35 AM",
+      "Minutes": 15.12,
+      "Latitude": 30.40355575864906,
+      "Longitude": -97.8547566837302,
+      "Time Updated": "3/14/2025 8:40 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 8:35 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52513698,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "7 ELEVEN #36564",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 8:06 AM",
+      "End Time": "3/14/2025 8:09 AM",
+      "Minutes": 2.97,
+      "Latitude": 30.40349205430656,
+      "Longitude": -97.8504721064281,
+      "Time Updated": "3/14/2025 8:40 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 8:09 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52513697,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "7 ELEVEN #36564",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 7:51 AM",
+      "End Time": "3/14/2025 8:06 AM",
+      "Minutes": 15.0,
+      "Latitude": 30.40349205430656,
+      "Longitude": -97.8504721064281,
+      "Time Updated": "3/14/2025 8:40 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 8:09 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52512890,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "TARGET #1953",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 7:38 AM",
+      "End Time": "3/14/2025 7:38 AM",
+      "Minutes": 0.22,
+      "Latitude": 30.40347506763327,
+      "Longitude": -97.85048575412816,
+      "Time Updated": "3/14/2025 8:05 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 7:43 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52512327,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 945584,
+      "Date": "3/14/2025",
+      "User": "Aaron Day",
+      "Customer Name": "TARGET #1953",
+      "Route": "600 Fri (2024)",
+      "Route Num": 600,
+      "Start Time": "3/14/2025 7:22 AM",
+      "End Time": "3/14/2025 7:24 AM",
+      "Minutes": 2.75,
+      "Latitude": 30.40347506763327,
+      "Longitude": -97.85048575412816,
+      "Time Updated": "3/14/2025 7:30 AM",
+      "Updated By": "API_1071",
+      "Time Created": "3/14/2025 7:24 AM",
+      "Created By": "aday"
+    }
+  ],
+  "unscheduled_stops": [
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.38953125,
+        "longitude": -97.89087024
+      },
+      "address": {
+        "id": 23570194,
+        "name": "MARSHALL FORD GROCERY",
+        "address": "4610 N HWY 620, AUSTIN, TX 78732"
+      },
+      "time_ms": 1741966677062,
+      "nearest_scheduled_distance": 650.0949130710815
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.38951271,
+        "longitude": -97.89085772
+      },
+      "address": {
+        "id": 23570194,
+        "name": "MARSHALL FORD GROCERY",
+        "address": "4610 N HWY 620, AUSTIN, TX 78732"
+      },
+      "time_ms": 1741967179117,
+      "nearest_scheduled_distance": 648.6891716124685
+    },
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.31701331,
+        "longitude": -97.95384564
+      },
+      "address": {
+        "id": 23570587,
+        "name": "TARGET #1812",
+        "address": "3702 RANCH ROAD 620 S, AUSTIN, TX 78738"
+      },
+      "time_ms": 1741976595021,
+      "nearest_scheduled_distance": 3676.596100038531
+    },
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.23543287,
+        "longitude": -97.87553197
+      },
+      "address": {
+        "name": "Highway 71 West, Austin, TX"
+      },
+      "time_ms": 1741978869004,
+      "nearest_scheduled_distance": 6173.914999005236
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.316966229,
+        "longitude": -97.953874619
+      },
+      "address": {
+        "id": 23570587,
+        "name": "TARGET #1812",
+        "address": "3702 RANCH ROAD 620 S, AUSTIN, TX 78738"
+      },
+      "time_ms": 1741977814023,
+      "nearest_scheduled_distance": 3680.9878628106385
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.23539533,
+        "longitude": -97.87551658
+      },
+      "address": {
+        "name": "Highway 71 West, Austin, TX"
+      },
+      "time_ms": 1741980299047,
+      "nearest_scheduled_distance": 6170.056000025983
+    }
+  ],
+  "alerts": [
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.402406,
+        "longitude": -97.850503
+      },
+      "description": "No GPS visit found for stop #2",
+      "details": {
+        "stop_id": 2858982,
+        "customer": "TARGET #1953"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.402406,
+        "longitude": -97.850503
+      },
+      "description": "No order entry found for stop #2",
+      "details": {
+        "stop_id": 2858982,
+        "customer": "TARGET #1953"
+      }
+    },
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.369461,
+        "longitude": -97.892539
+      },
+      "description": "No GPS visit found for stop #6",
+      "details": {
+        "stop_id": 2858928,
+        "customer": "REFUEL #1316"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.369461,
+        "longitude": -97.892539
+      },
+      "description": "No order entry found for stop #6",
+      "details": {
+        "stop_id": 2858928,
+        "customer": "REFUEL #1316"
+      }
+    },
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.369528,
+        "longitude": -97.892738
+      },
+      "description": "No GPS visit found for stop #8",
+      "details": {
+        "stop_id": 2862983,
+        "customer": "YETI LIQUOR"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.369528,
+        "longitude": -97.892738
+      },
+      "description": "No order entry found for stop #8",
+      "details": {
+        "stop_id": 2862983,
+        "customer": "YETI LIQUOR"
+      }
+    },
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.1986701,
+        "longitude": -97.8273606
+      },
+      "description": "No GPS visit found for stop #9",
+      "details": {
+        "stop_id": 2939248,
+        "customer": "CORK & BREW EXPRESS (RANCH RD)"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.1986701,
+        "longitude": -97.8273606
+      },
+      "description": "No order entry found for stop #9",
+      "details": {
+        "stop_id": 2939248,
+        "customer": "CORK & BREW EXPRESS (RANCH RD)"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.412476,
+        "longitude": -97.926553
+      },
+      "description": "No order entry found for stop #10",
+      "details": {
+        "stop_id": 2858958,
+        "customer": "HUDSON BEND GROCERY"
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.38953125,
+        "longitude": -97.89087024
+      },
+      "description": "Unscheduled arrival at MARSHALL FORD GROCERY",
+      "details": {
+        "address": "MARSHALL FORD GROCERY",
+        "nearest_scheduled_distance": 650.0949130710815
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.38951271,
+        "longitude": -97.89085772
+      },
+      "description": "Unscheduled departure at MARSHALL FORD GROCERY",
+      "details": {
+        "address": "MARSHALL FORD GROCERY",
+        "nearest_scheduled_distance": 648.6891716124685
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.31701331,
+        "longitude": -97.95384564
+      },
+      "description": "Unscheduled arrival at TARGET #1812",
+      "details": {
+        "address": "TARGET #1812",
+        "nearest_scheduled_distance": 3676.596100038531
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.23543287,
+        "longitude": -97.87553197
+      },
+      "description": "Unscheduled arrival at Highway 71 West, Austin, TX",
+      "details": {
+        "address": "Highway 71 West, Austin, TX",
+        "nearest_scheduled_distance": 6173.914999005236
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.316966229,
+        "longitude": -97.953874619
+      },
+      "description": "Unscheduled departure at TARGET #1812",
+      "details": {
+        "address": "TARGET #1812",
+        "nearest_scheduled_distance": 3680.9878628106385
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.23539533,
+        "longitude": -97.87551658
+      },
+      "description": "Unscheduled departure at Highway 71 West, Austin, TX",
+      "details": {
+        "address": "Highway 71 West, Austin, TX",
+        "nearest_scheduled_distance": 6170.056000025983
+      }
+    }
+  ],
+  "config": {
+    "alert_radius_meters": 100.0,
+    "unscheduled_stop_threshold_meters": 150.0
+  }
+}

--- a/tests/fixtures/metadata/route_metadata_RT603_February_18,_2025.json
+++ b/tests/fixtures/metadata/route_metadata_RT603_February_18,_2025.json
@@ -1,0 +1,1557 @@
+{
+  "version": "1.0",
+  "generated_at": "2025-07-24T20:53:08.442284",
+  "route_info": {
+    "route_number": 603,
+    "date": "February 18, 2025",
+    "vehicle_name": "CHA-AUS 301129 603",
+    "warehouse": {
+      "name": "Austin Warehouse",
+      "location": {
+        "latitude": 30.20037956,
+        "longitude": -97.71581548
+      }
+    }
+  },
+  "summary": {
+    "total_scheduled_stops": 11,
+    "total_gps_trips": 14,
+    "total_orders": 20,
+    "total_alerts": 14,
+    "stops_visited": 9,
+    "stops_with_orders": 8,
+    "unscheduled_stops": 9
+  },
+  "scheduled_stops": [
+    {
+      "stop_id": 2859707,
+      "sequence": 1,
+      "customer_name": "RANDALL'S #1850",
+      "location": {
+        "latitude": 30.184067,
+        "longitude": -97.847665
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739884450030,
+          "address": "RANDALL'S #1850",
+          "distance_meters": 47.15999133688724
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739882396040,
+          "address": "RANDALL'S #1850",
+          "distance_meters": 51.40164420689185
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "RANDALL'S #1850",
+          "start_time": "2/18/2025 6:45 AM",
+          "end_time": "2/18/2025 7:10 AM",
+          "duration_minutes": 24.78,
+          "user": "Aaron Day",
+          "distance_meters": 33.08062447748438
+        },
+        {
+          "customer_name": "RANDALL'S #1850",
+          "start_time": "2/18/2025 7:10 AM",
+          "end_time": "2/18/2025 7:12 AM",
+          "duration_minutes": 2.57,
+          "user": "Aaron Day",
+          "distance_meters": 33.08062447748438
+        },
+        {
+          "customer_name": "CORNER STORE #2095",
+          "start_time": "2/18/2025 7:18 AM",
+          "end_time": "2/18/2025 7:33 AM",
+          "duration_minutes": 15.78,
+          "user": "Aaron Day",
+          "distance_meters": 75.77874099314549
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2859699,
+      "sequence": 2,
+      "customer_name": "CVS #8387",
+      "location": {
+        "latitude": 30.1842815,
+        "longitude": -97.85003
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739889033027,
+          "address": "CVS #8387",
+          "distance_meters": 24.097838081252558
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739887263999,
+          "address": "CVS #8387",
+          "distance_meters": 17.664021717544117
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "7 ELEVEN #38267",
+          "start_time": "2/18/2025 8:34 AM",
+          "end_time": "2/18/2025 9:08 AM",
+          "duration_minutes": 34.0,
+          "user": "Aaron Day",
+          "distance_meters": 21.762062074972214
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2859695,
+      "sequence": 3,
+      "customer_name": "CORNER STORE #2095",
+      "location": {
+        "latitude": 30.18299999,
+        "longitude": -97.84962861
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739887173039,
+          "address": "CORNER STORE #2095",
+          "distance_meters": 27.81456689355996
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739884641016,
+          "address": "CORNER STORE #2095",
+          "distance_meters": 6.502810706489678
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "CORNER STORE #2095",
+          "start_time": "2/18/2025 7:53 AM",
+          "end_time": "2/18/2025 7:55 AM",
+          "duration_minutes": 2.05,
+          "user": "Aaron Day",
+          "distance_meters": 3.9000301156753845
+        },
+        {
+          "customer_name": "CVS #8387",
+          "start_time": "2/18/2025 8:17 AM",
+          "end_time": "2/18/2025 8:29 AM",
+          "duration_minutes": 12.23,
+          "user": "Aaron Day",
+          "distance_meters": 17.56466816240961
+        },
+        {
+          "customer_name": "CVS #8387",
+          "start_time": "2/18/2025 8:02 AM",
+          "end_time": "2/18/2025 8:17 AM",
+          "duration_minutes": 15.1,
+          "user": "Aaron Day",
+          "distance_meters": 17.56466816240961
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2859728,
+      "sequence": 4,
+      "customer_name": "C MART #10",
+      "location": {
+        "latitude": 30.179559,
+        "longitude": -97.840225
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739899228025,
+          "address": "C MART #10",
+          "distance_meters": 14.27122549405867
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739897344023,
+          "address": "C MART #10",
+          "distance_meters": 11.52428051757816
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "DOLLAR GENERAL #10315",
+          "start_time": "2/18/2025 11:26 AM",
+          "end_time": "2/18/2025 11:27 AM",
+          "duration_minutes": 1.0,
+          "user": "Aaron Day",
+          "distance_meters": 13.06134127288151
+        },
+        {
+          "customer_name": "C MART #10",
+          "start_time": "2/18/2025 11:17 AM",
+          "end_time": "2/18/2025 11:19 AM",
+          "duration_minutes": 2.42,
+          "user": "Aaron Day",
+          "distance_meters": 38.60700828292663
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2859732,
+      "sequence": 5,
+      "customer_name": "DOLLAR GENERAL #10315",
+      "location": {
+        "latitude": 30.176545,
+        "longitude": -97.823043
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739900289039,
+          "address": "DOLLAR GENERAL #10315",
+          "distance_meters": 18.39127343436205
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739899583162,
+          "address": "DOLLAR GENERAL #10315",
+          "distance_meters": 14.483205617086034
+        }
+      ],
+      "orders": [],
+      "has_gps_visit": true,
+      "has_order": false
+    },
+    {
+      "stop_id": 2859727,
+      "sequence": 6,
+      "customer_name": "BREAD BASKET (WEST GATE)",
+      "location": {
+        "latitude": 30.191133,
+        "longitude": -97.832677
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739897058029,
+          "address": "BREAD BASKET (WEST GATE)",
+          "distance_meters": 10.59325788912225
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739894329030,
+          "address": "BREAD BASKET (WEST GATE)",
+          "distance_meters": 13.444864321972515
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "C MART #10",
+          "start_time": "2/18/2025 10:49 AM",
+          "end_time": "2/18/2025 11:06 AM",
+          "duration_minutes": 17.45,
+          "user": "Aaron Day",
+          "distance_meters": 16.137618680679083
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2859703,
+      "sequence": 7,
+      "customer_name": "BIG BUCKET 3",
+      "location": {
+        "latitude": 30.195012,
+        "longitude": -97.843129
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739894140031,
+          "address": "BIG BUCKET 3",
+          "distance_meters": 12.145553686374681
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739893761046,
+          "address": "BIG BUCKET 3",
+          "distance_meters": 11.808959952297041
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "BREAD BASKET (WEST GATE)",
+          "start_time": "2/18/2025 10:00 AM",
+          "end_time": "2/18/2025 10:16 AM",
+          "duration_minutes": 15.52,
+          "user": "Aaron Day",
+          "distance_meters": 8.893304090146955
+        },
+        {
+          "customer_name": "BREAD BASKET (WEST GATE)",
+          "start_time": "2/18/2025 10:23 AM",
+          "end_time": "2/18/2025 10:40 AM",
+          "duration_minutes": 17.0,
+          "user": "Aaron Day",
+          "distance_meters": 8.893304090146955
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2860418,
+      "sequence": 8,
+      "customer_name": "7 ELEVEN #38267",
+      "location": {
+        "latitude": 30.199419,
+        "longitude": -97.862705
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739892332050,
+          "address": "7 ELEVEN #38267",
+          "distance_meters": 12.407455718008569
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739889297035,
+          "address": "7 ELEVEN #38267",
+          "distance_meters": 3.7759532465583026
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "WALGREENS #11513",
+          "start_time": "2/18/2025 9:23 AM",
+          "end_time": "2/18/2025 9:36 AM",
+          "duration_minutes": 12.4,
+          "user": "Aaron Day",
+          "distance_meters": 2.4266122646545703
+        },
+        {
+          "customer_name": "7 ELEVEN #38267",
+          "start_time": "2/18/2025 9:23 AM",
+          "end_time": "2/18/2025 9:23 AM",
+          "duration_minutes": 0.25,
+          "user": "Aaron Day",
+          "distance_meters": 16.335920799222603
+        },
+        {
+          "customer_name": "7 ELEVEN #38267",
+          "start_time": "2/18/2025 9:10 AM",
+          "end_time": "2/18/2025 9:23 AM",
+          "duration_minutes": 13.1,
+          "user": "Aaron Day",
+          "distance_meters": 16.335920799222603
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2859583,
+      "sequence": 9,
+      "customer_name": "WALGREENS #11513",
+      "location": {
+        "latitude": 30.199219,
+        "longitude": -97.864251
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1739893367106,
+          "address": "WALGREENS #11513",
+          "distance_meters": 13.113749514392763
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1739892398030,
+          "address": "WALGREENS #11513",
+          "distance_meters": 23.202878256043373
+        }
+      ],
+      "orders": [
+        {
+          "customer_name": "BIG BUCKET 3",
+          "start_time": "2/18/2025 9:53 AM",
+          "end_time": "2/18/2025 9:54 AM",
+          "duration_minutes": 0.6,
+          "user": "Aaron Day",
+          "distance_meters": 22.800130031739453
+        }
+      ],
+      "has_gps_visit": true,
+      "has_order": true
+    },
+    {
+      "stop_id": 2859094,
+      "sequence": 10,
+      "customer_name": "JD'S MARKET #4",
+      "location": {
+        "latitude": 30.1931913,
+        "longitude": -97.9251705
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    },
+    {
+      "stop_id": 2859095,
+      "sequence": 11,
+      "customer_name": "EASY LANE STOP",
+      "location": {
+        "latitude": 30.16127,
+        "longitude": -97.952762
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    }
+  ],
+  "gps_trips": [
+    {
+      "startMs": 1739880975325,
+      "endMs": 1739882396040,
+      "startLocation": "Flint Rock Loop, Austin, TX",
+      "endLocation": "West Slaughter Lane, Austin, TX",
+      "startAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "endAddress": {
+        "id": 23570594,
+        "name": "RANDALL'S #1850",
+        "address": "9911 BRODIE LN, AUSTIN, TX 78748"
+      },
+      "startCoordinates": {
+        "latitude": 30.20023017,
+        "longitude": -97.71742564
+      },
+      "endCoordinates": {
+        "latitude": 30.18403487,
+        "longitude": -97.84713256
+      },
+      "distanceMeters": 16586,
+      "fuelConsumedMl": 3054,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739884450030,
+      "endMs": 1739884641016,
+      "startLocation": "West Slaughter Lane, Austin, TX",
+      "endLocation": "West Slaughter Lane, Austin, TX",
+      "startAddress": {
+        "id": 23570594,
+        "name": "RANDALL'S #1850",
+        "address": "9911 BRODIE LN, AUSTIN, TX 78748"
+      },
+      "endAddress": {
+        "id": 23570316,
+        "name": "CORNER STORE #2095",
+        "address": "3419 SLAUGHTER LN W, AUSTIN, TX 78748"
+      },
+      "startCoordinates": {
+        "latitude": 30.18406313,
+        "longitude": -97.84717534
+      },
+      "endCoordinates": {
+        "latitude": 30.18304423,
+        "longitude": -97.849672949
+      },
+      "distanceMeters": 583,
+      "fuelConsumedMl": 170,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739887173039,
+      "endMs": 1739887263999,
+      "startLocation": "Brodie Lane, Austin, TX",
+      "endLocation": "West Slaughter Lane, Austin, TX",
+      "startAddress": {
+        "id": 23570316,
+        "name": "CORNER STORE #2095",
+        "address": "3419 SLAUGHTER LN W, AUSTIN, TX 78748"
+      },
+      "endAddress": {
+        "id": 23570091,
+        "name": "CVS #8387",
+        "address": "3500 W SLAUGHTER LN, AUSTIN, TX 78749"
+      },
+      "startCoordinates": {
+        "latitude": 30.18307274,
+        "longitude": -97.84990501
+      },
+      "endCoordinates": {
+        "latitude": 30.18413913,
+        "longitude": -97.85011237
+      },
+      "distanceMeters": 471,
+      "fuelConsumedMl": 0,
+      "tollMeters": 0,
+      "driverId": 0,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739889033027,
+      "endMs": 1739889297035,
+      "startLocation": "West Slaughter Lane, Austin, TX",
+      "endLocation": "Sendera Mesa Drive, Austin, TX",
+      "startAddress": {
+        "id": 23570091,
+        "name": "CVS #8387",
+        "address": "3500 W SLAUGHTER LN, AUSTIN, TX 78749"
+      },
+      "endAddress": {
+        "id": 23571495,
+        "name": "7 ELEVEN #38267",
+        "address": "5000 W SLAUGHTER LN, AUSTIN, TX 78749"
+      },
+      "startCoordinates": {
+        "latitude": 30.184141,
+        "longitude": -97.85022093
+      },
+      "endCoordinates": {
+        "latitude": 30.19938766,
+        "longitude": -97.86272036
+      },
+      "distanceMeters": 2334,
+      "fuelConsumedMl": 473,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739892332050,
+      "endMs": 1739892398030,
+      "startLocation": "West Slaughter Lane, Austin, TX",
+      "endLocation": "West Slaughter Lane, Austin, TX",
+      "startAddress": {
+        "id": 23571495,
+        "name": "7 ELEVEN #38267",
+        "address": "5000 W SLAUGHTER LN, AUSTIN, TX 78749"
+      },
+      "endAddress": {
+        "id": 23570734,
+        "name": "WALGREENS #11513",
+        "address": "5011 W SLAUGHTER LN, AUSTIN, TX 78749"
+      },
+      "startCoordinates": {
+        "latitude": 30.19949811,
+        "longitude": -97.862796149
+      },
+      "endCoordinates": {
+        "latitude": 30.19940854,
+        "longitude": -97.86435322
+      },
+      "distanceMeters": 205,
+      "fuelConsumedMl": 0,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739893367106,
+      "endMs": 1739893761046,
+      "startLocation": "West Slaughter Lane, Austin, TX",
+      "endLocation": "Davis Lane, Austin, TX",
+      "startAddress": {
+        "id": 23570734,
+        "name": "WALGREENS #11513",
+        "address": "5011 W SLAUGHTER LN, AUSTIN, TX 78749"
+      },
+      "endAddress": {
+        "id": 23571355,
+        "name": "BIG BUCKET 3",
+        "address": "8906 BRODIE LN, AUSTIN, TX 78748"
+      },
+      "startCoordinates": {
+        "latitude": 30.19933729,
+        "longitude": -97.86425232
+      },
+      "endCoordinates": {
+        "latitude": 30.19511783,
+        "longitude": -97.84314299
+      },
+      "distanceMeters": 2919,
+      "fuelConsumedMl": 582,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739894140031,
+      "endMs": 1739894329030,
+      "startLocation": "Davis Lane, Austin, TX",
+      "endLocation": "Davis Lane, Austin, TX",
+      "startAddress": {
+        "id": 23571355,
+        "name": "BIG BUCKET 3",
+        "address": "8906 BRODIE LN, AUSTIN, TX 78748"
+      },
+      "endAddress": {
+        "id": 23571074,
+        "name": "BREAD BASKET (WEST GATE)",
+        "address": "8801 W GATE BLVD, AUSTIN, TX 78745"
+      },
+      "startCoordinates": {
+        "latitude": 30.19512133,
+        "longitude": -97.8431372
+      },
+      "endCoordinates": {
+        "latitude": 30.19101994,
+        "longitude": -97.832626469
+      },
+      "distanceMeters": 1294,
+      "fuelConsumedMl": 244,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739897058029,
+      "endMs": 1739897344023,
+      "startLocation": "Davis Lane, Austin, TX",
+      "endLocation": "West Oak Woods, Austin, TX",
+      "startAddress": {
+        "id": 23571074,
+        "name": "BREAD BASKET (WEST GATE)",
+        "address": "8801 W GATE BLVD, AUSTIN, TX 78745"
+      },
+      "endAddress": {
+        "id": 23570016,
+        "name": "C MART #10",
+        "address": "3008 W SLAUGHTER LN STE B, AUSTIN, TX 78748"
+      },
+      "startCoordinates": {
+        "latitude": 30.191037529,
+        "longitude": -97.83268172
+      },
+      "endCoordinates": {
+        "latitude": 30.17955024,
+        "longitude": -97.84010577
+      },
+      "distanceMeters": 1730,
+      "fuelConsumedMl": 300,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739899228025,
+      "endMs": 1739899583162,
+      "startLocation": "West Oak Woods, Austin, TX",
+      "endLocation": "Monarch Drive, Austin, TX",
+      "startAddress": {
+        "id": 23570016,
+        "name": "C MART #10",
+        "address": "3008 W SLAUGHTER LN STE B, AUSTIN, TX 78748"
+      },
+      "endAddress": {
+        "id": 23570824,
+        "name": "DOLLAR GENERAL #10315",
+        "address": "9600 MANCHACA RD, AUSTIN, TX 78748"
+      },
+      "startCoordinates": {
+        "latitude": 30.1795712,
+        "longitude": -97.84007749
+      },
+      "endCoordinates": {
+        "latitude": 30.176595429,
+        "longitude": -97.82290428
+      },
+      "distanceMeters": 2850,
+      "fuelConsumedMl": 575,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739900289039,
+      "endMs": 1739900767026,
+      "startLocation": "Monarch Drive, Austin, TX",
+      "endLocation": "West Slaughter Lane, Austin, TX",
+      "startAddress": {
+        "id": 23570824,
+        "name": "DOLLAR GENERAL #10315",
+        "address": "9600 MANCHACA RD, AUSTIN, TX 78748"
+      },
+      "endAddress": {
+        "id": 23570356,
+        "name": "7 ELEVEN #36267",
+        "address": "525 W SLAUGHTER LN, AUSTIN, TX 78748"
+      },
+      "startCoordinates": {
+        "latitude": 30.17659417,
+        "longitude": -97.82286063
+      },
+      "endCoordinates": {
+        "latitude": 30.17184346,
+        "longitude": -97.79947541
+      },
+      "distanceMeters": 2900,
+      "fuelConsumedMl": 721,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739901156039,
+      "endMs": 1739901540032,
+      "startLocation": "West Slaughter Lane, Austin, TX",
+      "endLocation": "South Interstate 35, Austin, TX",
+      "startAddress": {
+        "id": 23570356,
+        "name": "7 ELEVEN #36267",
+        "address": "525 W SLAUGHTER LN, AUSTIN, TX 78748"
+      },
+      "endAddress": {
+        "id": 23571245,
+        "name": "VALERO #1570",
+        "address": "11206 IH 35 S, AUSTIN, TX 78748"
+      },
+      "startCoordinates": {
+        "latitude": 30.17185726,
+        "longitude": -97.79931566
+      },
+      "endCoordinates": {
+        "latitude": 30.13981996,
+        "longitude": -97.79704332
+      },
+      "distanceMeters": 4726,
+      "fuelConsumedMl": 858,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739901977093,
+      "endMs": 1739902764010,
+      "startLocation": "South Interstate 35, Austin, TX",
+      "endLocation": "Farm-to-Market Road 2001, Buda, TX",
+      "startAddress": {
+        "id": 23571245,
+        "name": "VALERO #1570",
+        "address": "11206 IH 35 S, AUSTIN, TX 78748"
+      },
+      "endAddress": {
+        "id": 23571292,
+        "name": "SNAX MAX (FM 201)",
+        "address": "204 FM 201, BUDA, TX 78610"
+      },
+      "startCoordinates": {
+        "latitude": 30.139784049,
+        "longitude": -97.79711285
+      },
+      "endCoordinates": {
+        "latitude": 30.076827439,
+        "longitude": -97.8220103
+      },
+      "distanceMeters": 8390,
+      "fuelConsumedMl": 1732,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739903014028,
+      "endMs": 1739904945009,
+      "startLocation": "Farm-to-Market Road 2001, Buda, TX",
+      "endLocation": "Nuckols Crossing Road, Austin, TX",
+      "startAddress": {
+        "id": 23571292,
+        "name": "SNAX MAX (FM 201)",
+        "address": "204 FM 201, BUDA, TX 78610"
+      },
+      "startCoordinates": {
+        "latitude": 30.07680302,
+        "longitude": -97.82199459
+      },
+      "endCoordinates": {
+        "latitude": 30.1922914,
+        "longitude": -97.73900478
+      },
+      "distanceMeters": 21029,
+      "fuelConsumedMl": 4174,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    },
+    {
+      "startMs": 1739905360039,
+      "endMs": 1739905876045,
+      "startLocation": "Nuckols Crossing Road, Austin, TX",
+      "endLocation": "Flint Rock Loop, Austin, TX",
+      "endAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "startCoordinates": {
+        "latitude": 30.19227652,
+        "longitude": -97.73897007
+      },
+      "endCoordinates": {
+        "latitude": 30.20022157,
+        "longitude": -97.71606975
+      },
+      "distanceMeters": 3157,
+      "fuelConsumedMl": 698,
+      "tollMeters": 0,
+      "driverId": 52240868,
+      "codriverIds": [],
+      "startOdometer": 0,
+      "endOdometer": 0,
+      "assetIds": []
+    }
+  ],
+  "orders": [
+    {
+      "Time Clock Event ID": 52022402,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "JD'S MARKET #4",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 1:11 PM",
+      "End Time": "2/18/2025 1:11 PM",
+      "Minutes": 0.08,
+      "Latitude": 30.20006803292489,
+      "Longitude": -97.7156430928436,
+      "Time Updated": "2/18/2025 1:30 PM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 1:11 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52022398,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "EASY LANE STOP",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 1:10 PM",
+      "End Time": "2/18/2025 1:11 PM",
+      "Minutes": 1.28,
+      "Latitude": 30.16680608971997,
+      "Longitude": -97.78512314902412,
+      "Time Updated": "2/18/2025 1:30 PM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 1:11 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52021193,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "POCO LOCO SUPERMERCADO (2009)",
+      "Route": "603 Mon (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 12:26 PM",
+      "End Time": "2/18/2025 12:27 PM",
+      "Minutes": 0.52,
+      "Latitude": 30.07678798183036,
+      "Longitude": -97.82201219115788,
+      "Time Updated": "2/18/2025 12:59 PM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 12:41 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52020531,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "SNAX MAX (FM 201)",
+      "Route": "603 Mon (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 12:20 PM",
+      "End Time": "2/18/2025 12:20 PM",
+      "Minutes": 0.42,
+      "Latitude": 30.07700952843552,
+      "Longitude": -97.82217888305836,
+      "Time Updated": "2/18/2025 12:25 PM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 12:22 PM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52018657,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "DOLLAR GENERAL #10315",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 11:26 AM",
+      "End Time": "2/18/2025 11:27 AM",
+      "Minutes": 1.0,
+      "Latitude": 30.17955144637655,
+      "Longitude": -97.84008966424568,
+      "Time Updated": "2/18/2025 11:49 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 11:37 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52017921,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "C MART #10",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 11:17 AM",
+      "End Time": "2/18/2025 11:19 AM",
+      "Minutes": 2.42,
+      "Latitude": 30.17935392251939,
+      "Longitude": -97.8405489844302,
+      "Time Updated": "2/18/2025 11:19 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 11:19 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52017920,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "C MART #10",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 10:49 AM",
+      "End Time": "2/18/2025 11:06 AM",
+      "Minutes": 17.45,
+      "Latitude": 30.1910190130291,
+      "Longitude": -97.83257276927532,
+      "Time Updated": "2/18/2025 11:19 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 11:19 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52016246,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "BREAD BASKET (WEST GATE)",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 10:23 AM",
+      "End Time": "2/18/2025 10:40 AM",
+      "Minutes": 17.0,
+      "Latitude": 30.1950814824476,
+      "Longitude": -97.8431751638111,
+      "Time Updated": "2/18/2025 10:49 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 10:42 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52016245,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "BREAD BASKET (WEST GATE)",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 10:00 AM",
+      "End Time": "2/18/2025 10:16 AM",
+      "Minutes": 15.52,
+      "Latitude": 30.1950814824476,
+      "Longitude": -97.8431751638111,
+      "Time Updated": "2/18/2025 10:49 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 10:42 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52014111,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "BIG BUCKET 3",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 9:53 AM",
+      "End Time": "2/18/2025 9:54 AM",
+      "Minutes": 0.6,
+      "Latitude": 30.19942432626644,
+      "Longitude": -97.86426475793922,
+      "Time Updated": "2/18/2025 10:14 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 9:54 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52013448,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "WALGREENS #11513",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 9:23 AM",
+      "End Time": "2/18/2025 9:36 AM",
+      "Minutes": 12.4,
+      "Latitude": 30.19944016892422,
+      "Longitude": -97.86271141398034,
+      "Time Updated": "2/18/2025 9:40 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 9:37 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52012895,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "7 ELEVEN #38267",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 9:23 AM",
+      "End Time": "2/18/2025 9:23 AM",
+      "Minutes": 0.25,
+      "Latitude": 30.19956381531469,
+      "Longitude": -97.86267359739884,
+      "Time Updated": "2/18/2025 9:40 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 9:23 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52012456,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "7 ELEVEN #38267",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 9:10 AM",
+      "End Time": "2/18/2025 9:23 AM",
+      "Minutes": 13.1,
+      "Latitude": 30.19956381531469,
+      "Longitude": -97.86267359739884,
+      "Time Updated": "2/18/2025 9:40 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 9:11 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52012454,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "7 ELEVEN #38267",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 8:34 AM",
+      "End Time": "2/18/2025 9:08 AM",
+      "Minutes": 34.0,
+      "Latitude": 30.18413299125765,
+      "Longitude": -97.85017777890629,
+      "Time Updated": "2/18/2025 9:40 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 9:11 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52010955,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "CVS #8387",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 8:17 AM",
+      "End Time": "2/18/2025 8:29 AM",
+      "Minutes": 12.23,
+      "Latitude": 30.18294623366018,
+      "Longitude": -97.84980017152972,
+      "Time Updated": "2/18/2025 8:35 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 8:29 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52010954,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "CVS #8387",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 8:02 AM",
+      "End Time": "2/18/2025 8:17 AM",
+      "Minutes": 15.1,
+      "Latitude": 30.18294623366018,
+      "Longitude": -97.84980017152972,
+      "Time Updated": "2/18/2025 8:35 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 8:29 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52009486,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "CORNER STORE #2095",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 7:53 AM",
+      "End Time": "2/18/2025 7:55 AM",
+      "Minutes": 2.05,
+      "Latitude": 30.18298023167575,
+      "Longitude": -97.84966211553665,
+      "Time Updated": "2/18/2025 7:59 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 7:55 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52009485,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "CORNER STORE #2095",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 7:18 AM",
+      "End Time": "2/18/2025 7:33 AM",
+      "Minutes": 15.78,
+      "Latitude": 30.1847298257334,
+      "Longitude": -97.84785741949251,
+      "Time Updated": "2/18/2025 7:59 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 7:55 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52008170,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "RANDALL'S #1850",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 7:10 AM",
+      "End Time": "2/18/2025 7:12 AM",
+      "Minutes": 2.57,
+      "Latitude": 30.18387065403588,
+      "Longitude": -97.84740633785114,
+      "Time Updated": "2/18/2025 7:29 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 7:12 AM",
+      "Created By": "aday"
+    },
+    {
+      "Time Clock Event ID": 52008169,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 937744,
+      "Date": "2/18/2025",
+      "User": "Aaron Day",
+      "Customer Name": "RANDALL'S #1850",
+      "Route": "603 Tue (2024)",
+      "Route Num": 603,
+      "Start Time": "2/18/2025 6:45 AM",
+      "End Time": "2/18/2025 7:10 AM",
+      "Minutes": 24.78,
+      "Latitude": 30.18387065403588,
+      "Longitude": -97.84740633785114,
+      "Time Updated": "2/18/2025 7:29 AM",
+      "Updated By": "API_1071",
+      "Time Created": "2/18/2025 7:12 AM",
+      "Created By": "aday"
+    }
+  ],
+  "unscheduled_stops": [
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.20023017,
+        "longitude": -97.71742564
+      },
+      "address": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "time_ms": 1739880975325,
+      "nearest_scheduled_distance": 10504.749613608245
+    },
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.17184346,
+        "longitude": -97.79947541
+      },
+      "address": {
+        "id": 23570356,
+        "name": "7 ELEVEN #36267",
+        "address": "525 W SLAUGHTER LN, AUSTIN, TX 78748"
+      },
+      "time_ms": 1739900767026,
+      "nearest_scheduled_distance": 2329.032242250036
+    },
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.13981996,
+        "longitude": -97.79704332
+      },
+      "address": {
+        "id": 23571245,
+        "name": "VALERO #1570",
+        "address": "11206 IH 35 S, AUSTIN, TX 78748"
+      },
+      "time_ms": 1739901540032,
+      "nearest_scheduled_distance": 4779.903118690747
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.17185726,
+        "longitude": -97.79931566
+      },
+      "address": {
+        "id": 23570356,
+        "name": "7 ELEVEN #36267",
+        "address": "525 W SLAUGHTER LN, AUSTIN, TX 78748"
+      },
+      "time_ms": 1739901156039,
+      "nearest_scheduled_distance": 2343.691422300674
+    },
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.076827439,
+        "longitude": -97.8220103
+      },
+      "address": {
+        "id": 23571292,
+        "name": "SNAX MAX (FM 201)",
+        "address": "204 FM 201, BUDA, TX 78610"
+      },
+      "time_ms": 1739902764010,
+      "nearest_scheduled_distance": 11054.596317871077
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.139784049,
+        "longitude": -97.79711285
+      },
+      "address": {
+        "id": 23571245,
+        "name": "VALERO #1570",
+        "address": "11206 IH 35 S, AUSTIN, TX 78748"
+      },
+      "time_ms": 1739901977093,
+      "nearest_scheduled_distance": 4779.790636062994
+    },
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.1922914,
+        "longitude": -97.73900478
+      },
+      "address": {
+        "name": "Nuckols Crossing Road, Austin, TX"
+      },
+      "time_ms": 1739904945009,
+      "nearest_scheduled_distance": 8279.600636424575
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.07680302,
+        "longitude": -97.82199459
+      },
+      "address": {
+        "id": 23571292,
+        "name": "SNAX MAX (FM 201)",
+        "address": "204 FM 201, BUDA, TX 78610"
+      },
+      "time_ms": 1739903014028,
+      "nearest_scheduled_distance": 11057.316874052027
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.19227652,
+        "longitude": -97.73897007
+      },
+      "address": {
+        "name": "Nuckols Crossing Road, Austin, TX"
+      },
+      "time_ms": 1739905360039,
+      "nearest_scheduled_distance": 8282.521479335555
+    }
+  ],
+  "alerts": [
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.176545,
+        "longitude": -97.823043
+      },
+      "description": "No order entry found for stop #5",
+      "details": {
+        "stop_id": 2859732,
+        "customer": "DOLLAR GENERAL #10315"
+      }
+    },
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.1931913,
+        "longitude": -97.9251705
+      },
+      "description": "No GPS visit found for stop #10",
+      "details": {
+        "stop_id": 2859094,
+        "customer": "JD'S MARKET #4"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.1931913,
+        "longitude": -97.9251705
+      },
+      "description": "No order entry found for stop #10",
+      "details": {
+        "stop_id": 2859094,
+        "customer": "JD'S MARKET #4"
+      }
+    },
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.16127,
+        "longitude": -97.952762
+      },
+      "description": "No GPS visit found for stop #11",
+      "details": {
+        "stop_id": 2859095,
+        "customer": "EASY LANE STOP"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.16127,
+        "longitude": -97.952762
+      },
+      "description": "No order entry found for stop #11",
+      "details": {
+        "stop_id": 2859095,
+        "customer": "EASY LANE STOP"
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.20023017,
+        "longitude": -97.71742564
+      },
+      "description": "Unscheduled departure at Austin Warehouse (AUS)",
+      "details": {
+        "address": "Austin Warehouse (AUS)",
+        "nearest_scheduled_distance": 10504.749613608245
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.17184346,
+        "longitude": -97.79947541
+      },
+      "description": "Unscheduled arrival at 7 ELEVEN #36267",
+      "details": {
+        "address": "7 ELEVEN #36267",
+        "nearest_scheduled_distance": 2329.032242250036
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.13981996,
+        "longitude": -97.79704332
+      },
+      "description": "Unscheduled arrival at VALERO #1570",
+      "details": {
+        "address": "VALERO #1570",
+        "nearest_scheduled_distance": 4779.903118690747
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.17185726,
+        "longitude": -97.79931566
+      },
+      "description": "Unscheduled departure at 7 ELEVEN #36267",
+      "details": {
+        "address": "7 ELEVEN #36267",
+        "nearest_scheduled_distance": 2343.691422300674
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.076827439,
+        "longitude": -97.8220103
+      },
+      "description": "Unscheduled arrival at SNAX MAX (FM 201)",
+      "details": {
+        "address": "SNAX MAX (FM 201)",
+        "nearest_scheduled_distance": 11054.596317871077
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.139784049,
+        "longitude": -97.79711285
+      },
+      "description": "Unscheduled departure at VALERO #1570",
+      "details": {
+        "address": "VALERO #1570",
+        "nearest_scheduled_distance": 4779.790636062994
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.1922914,
+        "longitude": -97.73900478
+      },
+      "description": "Unscheduled arrival at Nuckols Crossing Road, Austin, TX",
+      "details": {
+        "address": "Nuckols Crossing Road, Austin, TX",
+        "nearest_scheduled_distance": 8279.600636424575
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.07680302,
+        "longitude": -97.82199459
+      },
+      "description": "Unscheduled departure at SNAX MAX (FM 201)",
+      "details": {
+        "address": "SNAX MAX (FM 201)",
+        "nearest_scheduled_distance": 11057.316874052027
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.19227652,
+        "longitude": -97.73897007
+      },
+      "description": "Unscheduled departure at Nuckols Crossing Road, Austin, TX",
+      "details": {
+        "address": "Nuckols Crossing Road, Austin, TX",
+        "nearest_scheduled_distance": 8282.521479335555
+      }
+    }
+  ],
+  "config": {
+    "alert_radius_meters": 100.0,
+    "unscheduled_stop_threshold_meters": 150.0
+  }
+}

--- a/tests/fixtures/metadata/route_metadata_RT615_January_28,_2025.json
+++ b/tests/fixtures/metadata/route_metadata_RT615_January_28,_2025.json
@@ -1,0 +1,873 @@
+{
+  "version": "1.0",
+  "generated_at": "2025-07-24T20:53:08.502248",
+  "route_info": {
+    "route_number": 615,
+    "date": "January 28, 2025",
+    "vehicle_name": "CHA-AUS 001414 615",
+    "warehouse": {
+      "name": "Austin Warehouse",
+      "location": {
+        "latitude": 30.20037956,
+        "longitude": -97.71581548
+      }
+    }
+  },
+  "summary": {
+    "total_scheduled_stops": 5,
+    "total_gps_trips": 7,
+    "total_orders": 19,
+    "total_alerts": 10,
+    "stops_visited": 2,
+    "stops_with_orders": 0,
+    "unscheduled_stops": 2
+  },
+  "scheduled_stops": [
+    {
+      "stop_id": 2859530,
+      "sequence": 1,
+      "customer_name": "WALMART SUPERCENTER #1253",
+      "location": {
+        "latitude": 30.220938,
+        "longitude": -97.754263
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    },
+    {
+      "stop_id": 2862239,
+      "sequence": 2,
+      "customer_name": "HEB #765",
+      "location": {
+        "latitude": 30.22735,
+        "longitude": -97.887753
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    },
+    {
+      "stop_id": 2882882,
+      "sequence": 3,
+      "customer_name": "HEB #754",
+      "location": {
+        "latitude": 30.2386938,
+        "longitude": -97.7551818
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1738073843024,
+          "address": "HEB #754",
+          "distance_meters": 67.8800282190162
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1738066961015,
+          "address": "HEB #754",
+          "distance_meters": 68.4838683556862
+        }
+      ],
+      "orders": [],
+      "has_gps_visit": true,
+      "has_order": false
+    },
+    {
+      "stop_id": 2860840,
+      "sequence": 4,
+      "customer_name": "HEB #428",
+      "location": {
+        "latitude": 30.216138,
+        "longitude": -97.830761
+      },
+      "gps_visits": [
+        {
+          "type": "departure",
+          "time_ms": 1738084472014,
+          "address": "HEB #428",
+          "distance_meters": 75.9370750248933
+        },
+        {
+          "type": "arrival",
+          "time_ms": 1738081131009,
+          "address": "HEB #428",
+          "distance_meters": 66.36244783210265
+        }
+      ],
+      "orders": [],
+      "has_gps_visit": true,
+      "has_order": false
+    },
+    {
+      "stop_id": 2860839,
+      "sequence": 5,
+      "customer_name": "WALMART SUPERCENTER #2133",
+      "location": {
+        "latitude": 30.232553,
+        "longitude": -97.823095
+      },
+      "gps_visits": [],
+      "orders": [],
+      "has_gps_visit": false,
+      "has_order": false
+    }
+  ],
+  "gps_trips": [
+    {
+      "startMs": 1738058982113,
+      "endMs": 1738059937016,
+      "startLocation": "Flint Rock Loop, Austin, TX",
+      "endLocation": "Austin, TX",
+      "startAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "endAddress": {
+        "id": 23570589,
+        "name": "WALMART SUPERCENTER #1253",
+        "address": "710 E BEN WHITE BLVD, AUSTIN, TX 78704"
+      },
+      "startCoordinates": {
+        "latitude": 30.20051284,
+        "longitude": -97.71610929
+      },
+      "endCoordinates": {
+        "latitude": 30.221447759,
+        "longitude": -97.75335179
+      },
+      "distanceMeters": 10517,
+      "fuelConsumedMl": 2049,
+      "tollMeters": 0,
+      "driverId": 28834538,
+      "codriverIds": [],
+      "startOdometer": 42258000,
+      "endOdometer": 42258000,
+      "assetIds": []
+    },
+    {
+      "startMs": 1738066603021,
+      "endMs": 1738066961015,
+      "startLocation": "Austin, TX",
+      "endLocation": "South Congress Avenue, Austin, TX",
+      "startAddress": {
+        "id": 23570589,
+        "name": "WALMART SUPERCENTER #1253",
+        "address": "710 E BEN WHITE BLVD, AUSTIN, TX 78704"
+      },
+      "endAddress": {
+        "id": 246308458,
+        "name": "HEB #754",
+        "address": "2400 SOUTH CONGRESS AVE, AUSTIN, TX 78704"
+      },
+      "startCoordinates": {
+        "latitude": 30.22141728,
+        "longitude": -97.75338677
+      },
+      "endCoordinates": {
+        "latitude": 30.23815068,
+        "longitude": -97.75484276
+      },
+      "distanceMeters": 3265,
+      "fuelConsumedMl": 476,
+      "tollMeters": 0,
+      "driverId": 28834538,
+      "codriverIds": [],
+      "startOdometer": 42258000,
+      "endOdometer": 42258000,
+      "assetIds": []
+    },
+    {
+      "startMs": 1738073843024,
+      "endMs": 1738074975127,
+      "startLocation": "South Congress Avenue, Austin, TX",
+      "endLocation": "West US Highway 290, Austin, TX",
+      "startAddress": {
+        "id": 246308458,
+        "name": "HEB #754",
+        "address": "2400 SOUTH CONGRESS AVE, AUSTIN, TX 78704"
+      },
+      "endAddress": {
+        "id": 23571003,
+        "name": "CIRCLE K #2704684",
+        "address": "6412 W HIGHWAY 290, AUSTIN, TX 78735"
+      },
+      "startCoordinates": {
+        "latitude": 30.23815484,
+        "longitude": -97.754847089
+      },
+      "endCoordinates": {
+        "latitude": 30.23498918,
+        "longitude": -97.86263944
+      },
+      "distanceMeters": 11847,
+      "fuelConsumedMl": 2010,
+      "tollMeters": 0,
+      "driverId": 28834538,
+      "codriverIds": [],
+      "startOdometer": 42258000,
+      "endOdometer": 42258000,
+      "assetIds": []
+    },
+    {
+      "startMs": 1738075337038,
+      "endMs": 1738076103030,
+      "startLocation": "West US Highway 290, Austin, TX",
+      "endLocation": "Ranch Road 1826, Austin, TX",
+      "startAddress": {
+        "id": 23571003,
+        "name": "CIRCLE K #2704684",
+        "address": "6412 W HIGHWAY 290, AUSTIN, TX 78735"
+      },
+      "endAddress": {
+        "id": 27102693,
+        "name": "HEB #765",
+        "address": "7901 WEST HWY 290"
+      },
+      "startCoordinates": {
+        "latitude": 30.23513479,
+        "longitude": -97.86262423
+      },
+      "endCoordinates": {
+        "latitude": 30.22641388,
+        "longitude": -97.88706425
+      },
+      "distanceMeters": 5905,
+      "fuelConsumedMl": 1078,
+      "tollMeters": 0,
+      "driverId": 28834538,
+      "codriverIds": [],
+      "startOdometer": 42258000,
+      "endOdometer": 42258000,
+      "assetIds": []
+    },
+    {
+      "startMs": 1738080234029,
+      "endMs": 1738081131009,
+      "startLocation": "Twilight Mesa Drive, Austin, TX",
+      "endLocation": "Brodie Lane, Austin, TX",
+      "startAddress": {
+        "id": 27102693,
+        "name": "HEB #765",
+        "address": "7901 WEST HWY 290"
+      },
+      "endAddress": {
+        "id": 23570593,
+        "name": "HEB #428",
+        "address": "6900 BRODIE LN, AUSTIN, TX 78745"
+      },
+      "startCoordinates": {
+        "latitude": 30.22638263,
+        "longitude": -97.8869825
+      },
+      "endCoordinates": {
+        "latitude": 30.21668959,
+        "longitude": -97.830493149
+      },
+      "distanceMeters": 9338,
+      "fuelConsumedMl": 1268,
+      "tollMeters": 0,
+      "driverId": 0,
+      "codriverIds": [],
+      "startOdometer": 42258000,
+      "endOdometer": 42258000,
+      "assetIds": []
+    },
+    {
+      "startMs": 1738084472014,
+      "endMs": 1738084836028,
+      "startLocation": "Brodie Lane, Austin, TX",
+      "endLocation": "West US Highway 290, Sunset Valley, TX",
+      "startAddress": {
+        "id": 23570593,
+        "name": "HEB #428",
+        "address": "6900 BRODIE LN, AUSTIN, TX 78745"
+      },
+      "endAddress": {
+        "id": 23570588,
+        "name": "WALMART SUPERCENTER #2133",
+        "address": "5017 W HIGHWAY 290, AUSTIN, TX 78735"
+      },
+      "startCoordinates": {
+        "latitude": 30.2167639,
+        "longitude": -97.83044049
+      },
+      "endCoordinates": {
+        "latitude": 30.23172133,
+        "longitude": -97.822283279
+      },
+      "distanceMeters": 3464,
+      "fuelConsumedMl": 494,
+      "tollMeters": 0,
+      "driverId": 28834538,
+      "codriverIds": [],
+      "startOdometer": 42258000,
+      "endOdometer": 42258000,
+      "assetIds": []
+    },
+    {
+      "startMs": 1738089741027,
+      "endMs": 1738090617012,
+      "startLocation": "West US Highway 290, Sunset Valley, TX",
+      "endLocation": "Flint Rock Loop, Austin, TX",
+      "startAddress": {
+        "id": 23570588,
+        "name": "WALMART SUPERCENTER #2133",
+        "address": "5017 W HIGHWAY 290, AUSTIN, TX 78735"
+      },
+      "endAddress": {
+        "id": 107921550,
+        "name": "Austin Warehouse (AUS)",
+        "address": "6269 E Stassney Ln, Austin, TX 78744, USA"
+      },
+      "startCoordinates": {
+        "latitude": 30.23175045,
+        "longitude": -97.82226977
+      },
+      "endCoordinates": {
+        "latitude": 30.20032639,
+        "longitude": -97.715787359
+      },
+      "distanceMeters": 13134,
+      "fuelConsumedMl": 2239,
+      "tollMeters": 0,
+      "driverId": 28834538,
+      "codriverIds": [],
+      "startOdometer": 42258000,
+      "endOdometer": 42258000,
+      "assetIds": []
+    }
+  ],
+  "orders": [
+    {
+      "Time Clock Event ID": 51636357,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #765",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 12:28 PM",
+      "End Time": "1/28/2025 12:29 PM",
+      "Minutes": 1.02,
+      "Latitude": 30.22942026424523,
+      "Longitude": -97.79498607169651,
+      "Time Updated": "1/28/2025 12:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 12:29 PM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51636348,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "WALMART SUPERCENTER #1253",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 12:27 PM",
+      "End Time": "1/28/2025 12:28 PM",
+      "Minutes": 0.82,
+      "Latitude": 30.22942026424523,
+      "Longitude": -97.79498607169651,
+      "Time Updated": "1/28/2025 12:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 12:28 PM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51636308,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #754",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 12:26 PM",
+      "End Time": "1/28/2025 12:27 PM",
+      "Minutes": 0.8,
+      "Latitude": 30.22942026424523,
+      "Longitude": -97.79498607169651,
+      "Time Updated": "1/28/2025 12:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 12:27 PM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51636259,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #428",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 12:26 PM",
+      "End Time": "1/28/2025 12:26 PM",
+      "Minutes": 0.47,
+      "Latitude": 30.22942026424523,
+      "Longitude": -97.79498607169651,
+      "Time Updated": "1/28/2025 12:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 12:26 PM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51636235,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "WALMART SUPERCENTER #2133",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 12:24 PM",
+      "End Time": "1/28/2025 12:26 PM",
+      "Minutes": 1.62,
+      "Latitude": 30.22942026424523,
+      "Longitude": -97.79498607169651,
+      "Time Updated": "1/28/2025 12:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 12:26 PM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51636234,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "WALMART SUPERCENTER #2133",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 11:31 AM",
+      "End Time": "1/28/2025 12:24 PM",
+      "Minutes": 52.6,
+      "Latitude": 30.25645959202821,
+      "Longitude": -97.83821055105128,
+      "Time Updated": "1/28/2025 12:40 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 12:26 PM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51633958,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #428",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 11:07 AM",
+      "End Time": "1/28/2025 11:31 AM",
+      "Minutes": 24.25,
+      "Latitude": 30.1827543,
+      "Longitude": -97.8324748,
+      "Time Updated": "1/28/2025 12:05 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 11:32 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51633954,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #428",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 10:37 AM",
+      "End Time": "1/28/2025 11:07 AM",
+      "Minutes": 29.8,
+      "Latitude": 30.1827543,
+      "Longitude": -97.8324748,
+      "Time Updated": "1/28/2025 12:05 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 11:32 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51633952,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #428",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 9:38 AM",
+      "End Time": "1/28/2025 9:54 AM",
+      "Minutes": 15.45,
+      "Latitude": 30.2405794,
+      "Longitude": -97.9005706,
+      "Time Updated": "1/28/2025 12:05 PM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 11:32 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51629680,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931198,
+      "Date": "1/28/2025",
+      "User": "Maria Jaramillo",
+      "Customer Name": "HEB PLUS #91",
+      "Route": "615 Thu (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 10:01 AM",
+      "End Time": "1/28/2025 10:01 AM",
+      "Minutes": 0.37,
+      "Latitude": 30.23657353132059,
+      "Longitude": -97.72261988380713,
+      "Time Updated": "1/28/2025 10:20 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 10:01 AM",
+      "Created By": "MJaramillo"
+    },
+    {
+      "Time Clock Event ID": 51628818,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #765",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 9:38 AM",
+      "End Time": "1/28/2025 9:38 AM",
+      "Minutes": 0.18,
+      "Latitude": 30.2405794,
+      "Longitude": -97.9005706,
+      "Time Updated": "1/28/2025 9:45 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 9:38 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51628817,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #765",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 9:20 AM",
+      "End Time": "1/28/2025 9:38 AM",
+      "Minutes": 18.23,
+      "Latitude": 30.2405794,
+      "Longitude": -97.9005706,
+      "Time Updated": "1/28/2025 9:45 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 9:38 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51624885,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931229,
+      "Date": "1/28/2025",
+      "User": "Emanuel Flores",
+      "Customer Name": "WALMART SUPERCENTER #2133",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 7:55 AM",
+      "End Time": "1/28/2025 7:55 AM",
+      "Minutes": 0.15,
+      "Latitude": NaN,
+      "Longitude": NaN,
+      "Time Updated": "1/28/2025 7:55 AM",
+      "Updated By": "eflores",
+      "Time Created": "1/28/2025 7:55 AM",
+      "Created By": "eflores"
+    },
+    {
+      "Time Clock Event ID": 51624420,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #765",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 7:39 AM",
+      "End Time": "1/28/2025 7:39 AM",
+      "Minutes": 0.05,
+      "Latitude": 30.23481969656169,
+      "Longitude": -97.76417500875812,
+      "Time Updated": "1/28/2025 8:04 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 7:39 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51623917,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #754",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 7:15 AM",
+      "End Time": "1/28/2025 7:22 AM",
+      "Minutes": 7.15,
+      "Latitude": 30.23319595936411,
+      "Longitude": -97.7614394704192,
+      "Time Updated": "1/28/2025 7:30 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 7:22 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51622054,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "WALMART SUPERCENTER #1253",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 5:24 AM",
+      "End Time": "1/28/2025 6:16 AM",
+      "Minutes": 51.95,
+      "Latitude": 30.23218562046182,
+      "Longitude": -97.7593303912419,
+      "Time Updated": "1/28/2025 6:29 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 6:16 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51620728,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "WALMART SUPERCENTER #2133",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 5:23 AM",
+      "End Time": "1/28/2025 5:24 AM",
+      "Minutes": 1.08,
+      "Latitude": 30.23115722913095,
+      "Longitude": -97.76414368580004,
+      "Time Updated": "1/28/2025 5:24 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 5:24 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51620710,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #754",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 5:22 AM",
+      "End Time": "1/28/2025 5:23 AM",
+      "Minutes": 0.28,
+      "Latitude": 30.23115722913095,
+      "Longitude": -97.76414368580004,
+      "Time Updated": "1/28/2025 5:24 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 5:23 AM",
+      "Created By": "jlara"
+    },
+    {
+      "Time Clock Event ID": 51620705,
+      "Time Clock Activity": "Order Entry",
+      "Time Clock Shift": 931189,
+      "Date": "1/28/2025",
+      "User": "Janthony Lara",
+      "Customer Name": "HEB #765",
+      "Route": "615 Tue (2024)",
+      "Route Num": 615,
+      "Start Time": "1/28/2025 5:22 AM",
+      "End Time": "1/28/2025 5:22 AM",
+      "Minutes": 0.17,
+      "Latitude": 30.23115722913095,
+      "Longitude": -97.76414368580004,
+      "Time Updated": "1/28/2025 5:24 AM",
+      "Updated By": "API_1071",
+      "Time Created": "1/28/2025 5:22 AM",
+      "Created By": "jlara"
+    }
+  ],
+  "unscheduled_stops": [
+    {
+      "type": "arrival",
+      "location": {
+        "latitude": 30.23498918,
+        "longitude": -97.86263944
+      },
+      "address": {
+        "id": 23571003,
+        "name": "CIRCLE K #2704684",
+        "address": "6412 W HIGHWAY 290, AUSTIN, TX 78735"
+      },
+      "time_ms": 1738074975127,
+      "nearest_scheduled_distance": 2561.51489090201
+    },
+    {
+      "type": "departure",
+      "location": {
+        "latitude": 30.23513479,
+        "longitude": -97.86262423
+      },
+      "address": {
+        "id": 23571003,
+        "name": "CIRCLE K #2704684",
+        "address": "6412 W HIGHWAY 290, AUSTIN, TX 78735"
+      },
+      "time_ms": 1738075337038,
+      "nearest_scheduled_distance": 2568.2739543825364
+    }
+  ],
+  "alerts": [
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.220938,
+        "longitude": -97.754263
+      },
+      "description": "No GPS visit found for stop #1",
+      "details": {
+        "stop_id": 2859530,
+        "customer": "WALMART SUPERCENTER #1253"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.220938,
+        "longitude": -97.754263
+      },
+      "description": "No order entry found for stop #1",
+      "details": {
+        "stop_id": 2859530,
+        "customer": "WALMART SUPERCENTER #1253"
+      }
+    },
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.22735,
+        "longitude": -97.887753
+      },
+      "description": "No GPS visit found for stop #2",
+      "details": {
+        "stop_id": 2862239,
+        "customer": "HEB #765"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.22735,
+        "longitude": -97.887753
+      },
+      "description": "No order entry found for stop #2",
+      "details": {
+        "stop_id": 2862239,
+        "customer": "HEB #765"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.2386938,
+        "longitude": -97.7551818
+      },
+      "description": "No order entry found for stop #3",
+      "details": {
+        "stop_id": 2882882,
+        "customer": "HEB #754"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.216138,
+        "longitude": -97.830761
+      },
+      "description": "No order entry found for stop #4",
+      "details": {
+        "stop_id": 2860840,
+        "customer": "HEB #428"
+      }
+    },
+    {
+      "type": "missed_stop",
+      "severity": "high",
+      "location": {
+        "latitude": 30.232553,
+        "longitude": -97.823095
+      },
+      "description": "No GPS visit found for stop #5",
+      "details": {
+        "stop_id": 2860839,
+        "customer": "WALMART SUPERCENTER #2133"
+      }
+    },
+    {
+      "type": "no_order",
+      "severity": "medium",
+      "location": {
+        "latitude": 30.232553,
+        "longitude": -97.823095
+      },
+      "description": "No order entry found for stop #5",
+      "details": {
+        "stop_id": 2860839,
+        "customer": "WALMART SUPERCENTER #2133"
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.23498918,
+        "longitude": -97.86263944
+      },
+      "description": "Unscheduled arrival at CIRCLE K #2704684",
+      "details": {
+        "address": "CIRCLE K #2704684",
+        "nearest_scheduled_distance": 2561.51489090201
+      }
+    },
+    {
+      "type": "unscheduled_stop",
+      "severity": "low",
+      "location": {
+        "latitude": 30.23513479,
+        "longitude": -97.86262423
+      },
+      "description": "Unscheduled departure at CIRCLE K #2704684",
+      "details": {
+        "address": "CIRCLE K #2704684",
+        "nearest_scheduled_distance": 2568.2739543825364
+      }
+    }
+  ],
+  "config": {
+    "alert_radius_meters": 100.0,
+    "unscheduled_stop_threshold_meters": 150.0
+  }
+}


### PR DESCRIPTION
## Summary
- ignore orders missing coordinates before geospatial lookup
- generate new sample metadata for routes 600, 603, and 615

## Testing
- `ruff check jeco_route_processor/route_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829c6e20f48328bd60b4ed21b32879